### PR TITLE
Add more careful check for version IRIs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 
 jobs:
   tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,24 @@
+name: Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          pip install tox
+      - name: Run tests
+        run:
+          tox -e doctests

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ debug.Makefile
 profile.txt
 .ipynb_checkpoints
 .tox
+.venv

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ test.sh
 debug.Makefile
 profile.txt
 .ipynb_checkpoints
-.tox/.package.lock
+.tox

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ test.sh
 debug.Makefile
 profile.txt
 .ipynb_checkpoints
+.tox/.package.lock

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[testenv:doctests]
+skip_install = true
+commands =
+    xdoctest util/dashboard/fp_004.py
+deps =
+    xdoctest
+    pygments

--- a/tox.ini
+++ b/tox.ini
@@ -5,3 +5,5 @@ commands =
 deps =
     xdoctest
     pygments
+    pyyaml
+    requests

--- a/util/dashboard/fp_004.py
+++ b/util/dashboard/fp_004.py
@@ -125,7 +125,19 @@ def url_exists(url: str) -> bool:
 
 
 def get_iri_version_error_message(version_iri: str) -> Optional[str]:
-    """Check a version IRI has exactly one of a semantic version or ISO 8601 date (YYYY-MM-DD) in it."""
+    """Check a version IRI has exactly one of a semantic version or ISO 8601 date (YYYY-MM-DD) in it.
+
+    >>> get_iri_version_error_message("https://example.org/2022-01-01/ontology.owl")
+    None
+    >>> get_iri_version_error_message("https://example.org/1.0.0/ontology.owl")
+    None
+    >>> get_iri_version_error_message("https://example.org/1.0/ontology.owl")
+    None
+    >>> get_iri_version_error_message("https://obofoundry.org")
+    'Version IRI has neither a semantic version nor a date'
+    >>> get_iri_version_error_message("https://example.org/2022-01-01/1.0.0/ontology.owl")
+    'Version IRI should not contain both a semantic version and date'
+    """
     matches_semver = SEMVER_PATTERN.match(version_iri)
     matches_date = DATE_PATTERN.match(version_iri)
     if matches_date and matches_semver:

--- a/util/dashboard/fp_004.py
+++ b/util/dashboard/fp_004.py
@@ -122,6 +122,10 @@ def contains_semver(iri: str) -> bool:
     False
     >>> contains_semver("https://example.org/2022-01-01/ontology.owl")
     False
+    >>> contains_semver("http://purl.obolibrary.org/obo/chebi/223/chebi.owl")
+    True
+    >>> contains_semver("http://purl.obolibrary.org/obo/pr/68.0/pr.owl")
+    True
     """
     return _match_any_part(iri, SEMVER_PATTERN)
 
@@ -139,6 +143,10 @@ def contains_date(iri: str) -> bool:
     False
     >>> contains_date("https://example.org/2022-01-01/ontology.owl")
     True
+    >>> contains_date("http://purl.obolibrary.org/obo/chebi/223/chebi.owl")
+    False
+    >>> contains_date("http://purl.obolibrary.org/obo/pr/68.0/pr.owl")
+    False
     """
     return _match_any_part(iri, DATE_PATTERN)
 
@@ -159,6 +167,10 @@ def get_iri_version_error_message(version_iri: str) -> Optional[str]:
     >>> get_iri_version_error_message("https://example.org/1.0.0/ontology.owl")
     None
     >>> get_iri_version_error_message("https://example.org/1.0/ontology.owl")
+    None
+    >>> get_iri_version_error_message("http://purl.obolibrary.org/obo/chebi/223/chebi.owl")
+    None
+    >>> get_iri_version_error_message("http://purl.obolibrary.org/obo/pr/68.0/pr.owl")
     None
     >>> get_iri_version_error_message("https://obofoundry.org")
     'Version IRI has neither a semantic version nor a date'

--- a/util/dashboard/fp_004.py
+++ b/util/dashboard/fp_004.py
@@ -29,8 +29,6 @@ import re
 
 import requests
 
-from dash_utils import format_msg
-
 # regex pattern to match dated version IRIs
 pat = r'http:\/\/purl\.obolibrary\.org/obo/.*/([0-9]{4}-[0-9]{2}-[0-9]{2})/.*'
 PATTERN = re.compile(pat)
@@ -124,6 +122,40 @@ def url_exists(url: str) -> bool:
         return rv
 
 
+def contains_semver(s: str) -> bool:
+    """Return if the string contains a semantic version substring.
+
+    >>> contains_semver("https://example.org/1.0.0/ontology.owl")
+    True
+    >>> contains_semver("https://example.org/1.0/ontology.owl")
+    True
+    >>> contains_semver("https://example.org/2022-01-01/1.0.0/ontology.owl")
+    True
+    >>> contains_semver("https://example.org/ontology.owl")
+    False
+    >>> contains_semver("https://example.org/2022-01-01/ontology.owl")
+    False
+    """
+    return bool(SEMVER_PATTERN.match(s))
+
+
+def contains_date(s: str) -> bool:
+    """Return if the string contains a date substring.
+
+    >>> contains_date("https://example.org/1.0.0/ontology.owl")
+    False
+    >>> contains_date("https://example.org/1.0/ontology.owl")
+    False
+    >>> contains_date("https://example.org/2022-01-01/1.0.0/ontology.owl")
+    True
+    >>> contains_date("https://example.org/ontology.owl")
+    False
+    >>> contains_date("https://example.org/2022-01-01/ontology.owl")
+    True
+    """
+    return bool(DATE_PATTERN.match(s))
+
+
 def get_iri_version_error_message(version_iri: str) -> Optional[str]:
     """Check a version IRI has exactly one of a semantic version or ISO 8601 date (YYYY-MM-DD) in it.
 
@@ -138,8 +170,8 @@ def get_iri_version_error_message(version_iri: str) -> Optional[str]:
     >>> get_iri_version_error_message("https://example.org/2022-01-01/1.0.0/ontology.owl")
     'Version IRI should not contain both a semantic version and date'
     """
-    matches_semver = SEMVER_PATTERN.match(version_iri)
-    matches_date = DATE_PATTERN.match(version_iri)
+    matches_semver = contains_semver(version_iri)
+    matches_date = contains_date(version_iri)
     if matches_date and matches_semver:
         return "Version IRI should not contain both a semantic version and date"
     if not matches_date and not matches_semver:

--- a/util/dashboard/fp_004.py
+++ b/util/dashboard/fp_004.py
@@ -34,8 +34,10 @@ from dash_utils import format_msg
 # regex pattern to match dated version IRIs
 pat = r'http:\/\/purl\.obolibrary\.org/obo/.*/([0-9]{4}-[0-9]{2}-[0-9]{2})/.*'
 PATTERN = re.compile(pat)
-SEMVER_PATTERN = re.compile("...")
-DATE_PATTERN = re.compile("...")
+#: Official regex for semantic versions from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+SEMVER_PATTERN = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$")
+#: Regular expression for ISO 8601 compliant date in YYYY-MM-DD format
+DATE_PATTERN = re.compile(r"^([0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])$")
 
 # descriptions of issues
 bad_format = 'Version IRI \'{0}\' is not in recommended format'
@@ -131,4 +133,3 @@ def url_has_version(url: str) -> Optional[str]:
         return "Version IRI has neither a semantic version nor a date"
     # None means it's all gucci
     return None
-

--- a/util/dashboard/fp_004.py
+++ b/util/dashboard/fp_004.py
@@ -35,9 +35,9 @@ from dash_utils import format_msg
 pat = r'http:\/\/purl\.obolibrary\.org/obo/.*/([0-9]{4}-[0-9]{2}-[0-9]{2})/.*'
 PATTERN = re.compile(pat)
 #: Official regex for semantic versions from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-SEMVER_PATTERN = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$")
+SEMVER_PATTERN = re.compile(r"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?")
 #: Regular expression for ISO 8601 compliant date in YYYY-MM-DD format
-DATE_PATTERN = re.compile(r"^([0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])$")
+DATE_PATTERN = re.compile(r"([0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])")
 
 # descriptions of issues
 bad_format = 'Version IRI \'{0}\' is not in recommended format'

--- a/util/dashboard/fp_004.py
+++ b/util/dashboard/fp_004.py
@@ -68,9 +68,9 @@ def has_versioning(ontology):
     if not url_exists(version_iri):
         return {"status": "ERROR", "comment": "Version IRI does not resolve"}
 
-    has_version_message = iri_has_version(version_iri)
-    if has_version_message is not None:
-        return {"status": "ERROR", "comment": has_version_message}
+    iri_version_error_message = get_iri_version_error_message(version_iri)
+    if iri_version_error_message is not None:
+        return {"status": "ERROR", "comment": iri_version_error_message}
 
     # compare version IRI to the regex pattern
     if not PATTERN.search(version_iri):
@@ -124,7 +124,7 @@ def url_exists(url: str) -> bool:
         return rv
 
 
-def iri_has_version(version_iri: str) -> Optional[str]:
+def get_iri_version_error_message(version_iri: str) -> Optional[str]:
     """Check a version IRI has exactly one of a semantic version or ISO 8601 date (YYYY-MM-DD) in it."""
     matches_semver = SEMVER_PATTERN.match(version_iri)
     matches_date = DATE_PATTERN.match(version_iri)

--- a/util/dashboard/fp_004.py
+++ b/util/dashboard/fp_004.py
@@ -68,7 +68,7 @@ def has_versioning(ontology):
     if not url_exists(version_iri):
         return {"status": "ERROR", "comment": "Version IRI does not resolve"}
 
-    has_version_message = url_has_version(version_iri)
+    has_version_message = iri_has_version(version_iri)
     if has_version_message is not None:
         return {"status": "ERROR", "comment": has_version_message}
 
@@ -124,9 +124,10 @@ def url_exists(url: str) -> bool:
         return rv
 
 
-def url_has_version(url: str) -> Optional[str]:
-    matches_semver = SEMVER_PATTERN.match(url)
-    matches_date = DATE_PATTERN.match(url)
+def iri_has_version(version_iri: str) -> Optional[str]:
+    """Check a version IRI has exactly one of a semantic version or ISO 8601 date (YYYY-MM-DD) in it."""
+    matches_semver = SEMVER_PATTERN.match(version_iri)
+    matches_date = DATE_PATTERN.match(version_iri)
     if matches_date and matches_semver:
         return "Version IRI should not contain both a semantic version and date"
     if not matches_date and not matches_semver:


### PR DESCRIPTION
Closes https://github.com/OBOFoundry/OBOFoundry.github.io/issues/2370

This PR adds a check that a version IRI contains exactly one of:

1. A semantic version (see https://semver.org for exaplanation of semantic versioning, regex ideas from https://gist.github.com/jhorsman/62eeea161a13b80e39f5249281e17c39)
2. An ISO 8601-compliant date (e.g., no american or european nonsense)

Depends on:

- [x] https://github.com/OBOFoundry/OBOFoundry.github.io/issues/1921