### PR TITLE
Update ontology page

### DIFF
--- a/util/dashboard_config.py
+++ b/util/dashboard_config.py
@@ -432,7 +432,7 @@ def prepare_ontologies(ontologies, ontology_dir, dashboard_dir, make_parameters,
                     save_yaml(ont_results, ont_results_path)
                     continue
             else:
-                logging.info(f"Not runnning dashboard for {o} because it has not changed ({ont_results['changed']}) "
+                logging.info(f"Not running dashboard for {o} because it has not changed ({ont_results['changed']}) "
                              f"nor forced ({force})..")
         else:
             logging.info(f"{o} has a results file, but no metrics were computed ({'metrics' not in ont_results}), "

--- a/util/templates/ontology.html.jinja2
+++ b/util/templates/ontology.html.jinja2
@@ -83,12 +83,14 @@
                                 <td>{{ m }}</td>
                                 {% set value = metrics[m] %}
                                 {% if value is mapping %}
-                                    <td><dl>
-                                        {% for ns in value %}
-                                            <dt>{{ ns }}</dt>
-                                            <dd>{{ value[ns] }}</dd>
-                                        {% endfor %}
-                                    </dl></td>
+                                    <td>
+                                        <dl class="row">
+                                            {% for ns in value %}
+                                                <dt class="col-sm-3 text-right">{{ ns }}</dt>
+                                                <dd class="col-sm-9 text-left">{{ value[ns] }}</dd>
+                                            {% endfor %}
+                                        </dl>
+                                    </td>
                                 {% elif value is list %}
                                     <td><ul>
                                         {% for lvalue in value %}

--- a/util/templates/ontology.html.jinja2
+++ b/util/templates/ontology.html.jinja2
@@ -83,9 +83,16 @@
                                 <td>{{ m }}</td>
                                 {% set value = metrics[m] %}
                                 {% if value is mapping %}
-                                    <td><ul>
+                                    <td><dl>
                                         {% for ns in value %}
-                                        <li>{{ ns }}: {{ value[ns] }}</li>
+                                            <dt>{{ ns }}</dt>
+                                            <dd>{{ value[ns] }}</dd>
+                                        {% endfor %}
+                                    </dl></td>
+                                {% elif value is list %}
+                                    <td><ul>
+                                        {% for lvalue in value %}
+                                            <li>{{ lvalue }}</li>
                                         {% endfor %}
                                     </ul></td>
                                 {% else %}


### PR DESCRIPTION
This PR makes two updates:

1. Uses the "definition list" `<dl>` tag for displaying mapping, which assigns some semantic meaning to the keys and values
2. Checks for values being lists and uses an unordered list `<ul>` for their values. I think this only happens for
 the usages key.
3. Fixes a typo