### PR TITLE
Ensure ROBOT report only runs over base entities

### DIFF
--- a/util/dashboard/dashboard.py
+++ b/util/dashboard/dashboard.py
@@ -179,6 +179,11 @@ def run():
         # Get the report based on if it's big or not
         report = None
         good_format = None
+        
+        for base_iri in data['base_ns']:
+            logging.warning(f"Adding base IRI to IO Helper: {base_iri}.")
+            io_helper.addBaseNamespace(base_iri)
+        
         if big:
             if namespace != 'gaz':
                 # Report currently takes TOO LONG for GAZ


### PR DESCRIPTION
Unfortunately it does not work. 

I have ensured that IO helper actually has the correct base namespaces set before passing it to getReport() in ROBOT. 


https://github.com/OBOFoundry/OBO-Dashboard/blob/master/util/dashboard/report_utils.py#L32


If I do (printing to make sure I am looking at the right place):


```
for s in io_helper.getBaseNamespaces():
        print(f"IO:::{s}")

  try:
      report = robot_gateway.ReportOperation.getReport(
          ontology, io_helper, report_options)
  except Py4JJavaError as err:
      msg = err.java_exception.getMessage()
      print('REPORT FAILED\n' + str(msg))
      return None
  
  print(report.toCSV())
```

I see (output truncated for illustrative purposes):

```
IO:::http://purl.obolibrary.org/obo/omo#
IO:::http://purl.obolibrary.org/obo/OMO_
Level,Rule Name,Subject,Property,Value
WARN,annotation_whitespace,IAO:0000115,IAO:0000116,<2012-0..
WARN,annotation_whitespace,IAO:0000424,IAO:0000112,< 2151 , <= 2300]@en>
WARN,missing_definition,IAO:0000027,IAO:0000115,
WARN,missing_definition,IAO:0000030,IAO:0000115,
WARN,missing_definition,IAO:8000019,IAO:0000115,WARN,missing_definition,IAO:8000020,IAO:0000115,
See dashboard/omo/robot_report.tsv for details

```

So it still includes IAO entities despite the base NS being set in the io helper.

It is using the correct ROBOT version (1.8.3); at least I am pretty sure I do (it says so in the output, but I don't know how exactly the java bindings work).

I tried the command using Java directly. Works. 