### PR TITLE
Update how to get prefix from new obo context

### DIFF
--- a/util/create_report_html.py
+++ b/util/create_report_html.py
@@ -87,7 +87,7 @@ def maybe_get_link(cell, context):
             prefix = curie.group(1)
             local_id = curie.group(2)
             if prefix in context:
-                namespace = context[prefix]
+                namespace = context[prefix]["@id"]
                 url = namespace + local_id
             elif prefix in other_prefixes:
                 namespace = other_prefixes[prefix]


### PR DESCRIPTION
[OBO context](https://github.com/OBOFoundry/OBOFoundry.github.io/blob/master/registry/obo_context.jsonld) was updated recently defining the prefixes with dict, so this is updating how to retrieve them.