### PR TITLE
Add columns when writing empty report

### DIFF
--- a/dashboard-config.yml
+++ b/dashboard-config.yml
@@ -36,6 +36,7 @@ ontologies:
   custom:
     - id: agro
     - id: omo
+    - id: ro
     #- id: genepio
     # - id: covoc
     #   mirror_from: "https://raw.githubusercontent.com/EBISPOT/covoc/master/covoc.owl"

--- a/util/dashboard/dash_utils.py
+++ b/util/dashboard/dash_utils.py
@@ -262,12 +262,12 @@ def whitespace_only(file):
     return re.search(r'^\s*$', content)
 
 
-def write_empty(file):
-    """Write an empty FP3 report.
+def write_empty(file, columns):
+    """Write an empty report.
 
     Args:
         ontology_dir (str):
     """
     file = os.path.join(file)
-    with open(file, 'w+') as f:
-        f.write('')
+    with open(file, 'w+', encoding='utf-8') as f:
+        f.write('\t'.join(columns))

--- a/util/dashboard/fp_003.py
+++ b/util/dashboard/fp_003.py
@@ -56,7 +56,7 @@ def has_valid_uris(robot_gateway, namespace, ontology, ontology_dir):
         otherwise.
     """
     if not ontology:
-        dash_utils.write_empty(os.path.join(ontology_dir, 'fp3.tsv'), ["Status, Issue"])
+        dash_utils.write_empty(os.path.join(ontology_dir, 'fp3.tsv'), ["Status", "Issue"])
         return {'status': 'ERROR', 'comment': 'Unable to load ontology'}
 
     entities = robot_gateway.OntologyHelper.getEntities(ontology)

--- a/util/dashboard/fp_003.py
+++ b/util/dashboard/fp_003.py
@@ -56,7 +56,7 @@ def has_valid_uris(robot_gateway, namespace, ontology, ontology_dir):
         otherwise.
     """
     if not ontology:
-        dash_utils.write_empty(os.path.join(ontology_dir, 'fp3.tsv'))
+        dash_utils.write_empty(os.path.join(ontology_dir, 'fp3.tsv'), ["Status, Issue"])
         return {'status': 'ERROR', 'comment': 'Unable to load ontology'}
 
     entities = robot_gateway.OntologyHelper.getEntities(ontology)
@@ -129,7 +129,7 @@ def big_has_valid_uris(namespace, file, ontology_dir):
             if 'Ontology' and 'about' in line:
                 if not owl and not rdf:
                     # did not find OWL and RDF - end now
-                    dash_utils.write_empty(os.path.join(ontology_dir, 'fp3.tsv'))
+                    dash_utils.write_empty(os.path.join(ontology_dir, 'fp3.tsv'), ["Status", "Issue"])
                     return {'status': 'ERROR',
                             'comment': 'Unable to parse ontology'}
 
@@ -167,7 +167,7 @@ def big_has_valid_uris(namespace, file, ontology_dir):
 
     if not valid:
         # not valid ontology
-        dash_utils.write_empty(os.path.join(ontology_dir, 'fp3.tsv'))
+        dash_utils.write_empty(os.path.join(ontology_dir, 'fp3.tsv'), ["Status", "Issue"])
         return {'status': 'ERROR',
                 'comment': 'Unable to parse ontology'}
 

--- a/util/dashboard/fp_007.py
+++ b/util/dashboard/fp_007.py
@@ -55,12 +55,12 @@ def has_valid_relations(namespace, ontology, ro_props, ontology_dir):
         PASS or violation level with optional help message
     """
     if ontology is None:
-        dash_utils.write_empty(os.path.join(ontology_dir, 'fp7.tsv'))
+        dash_utils.write_empty(os.path.join(ontology_dir, 'fp7.tsv'), ["IRI", "Label", "Issue"])
         return {'status': 'ERROR', 'comment': 'Unable to load ontology'}
 
     # ignore RO
     if namespace == 'ro':
-        dash_utils.write_empty(os.path.join(ontology_dir, 'fp7.tsv'))
+        dash_utils.write_empty(os.path.join(ontology_dir, 'fp7.tsv'), ["IRI", "Label", "Issue"])
         return {'status': 'PASS'}
 
     props = get_properties(ontology)
@@ -170,12 +170,12 @@ def big_has_valid_relations(namespace, file, ro_props, ontology_dir):
         PASS or violation level with optional help message
     """
     if not os.path.isfile(file):
-        dash_utils.write_empty(os.path.join(ontology_dir, 'fp7.tsv'))
+        dash_utils.write_empty(os.path.join(ontology_dir, 'fp7.tsv'), ["IRI","Label","Issue"])
         return {'status': 'ERROR', 'comment': 'Unable to find ontology file'}
 
     # ignore RO
     if namespace == 'ro':
-        dash_utils.write_empty(os.path.join(ontology_dir, 'fp7.tsv'))
+        dash_utils.write_empty(os.path.join(ontology_dir, 'fp7.tsv'), ["IRI","Label","Issue"])
         return {'status': 'PASS'}
 
     props = big_get_properties(file)


### PR DESCRIPTION
Fixes #115

The report for the FP 7 (Relations not in RO) is ignored for RO, then the report was completely empty, not even columns.

Added RO to the test QC.