### PR TITLE
Generalise the report generation for ROBOT report and FP3 and FP7 reports

### DIFF
--- a/util/create_report_html.py
+++ b/util/create_report_html.py
@@ -31,7 +31,7 @@ def main(args):
                         help='Output report HTML file')
     parser.add_argument('limitlines',
                         type=int,
-                        help='Parameter to limit lines', nargs='?', default=0)
+                        help='Parameter to limit lines', nargs='?', default=50)
     args = parser.parse_args()
 
     context = json.load(args.context)['@context']
@@ -41,8 +41,9 @@ def main(args):
 
     try:
         report = pd.read_csv(args.report, sep="\t")
-        error_count_level = report["Level"].value_counts()
-        error_count_rule = report["Rule Name"].value_counts()
+        if "Level" in report.columns and "Rule Name" in report.columns:
+            error_count_level = report["Level"].value_counts()
+            error_count_rule = report["Rule Name"].value_counts()
     except Exception:
         print("No report")
 

--- a/util/templates/report.html.jinja2
+++ b/util/templates/report.html.jinja2
@@ -8,6 +8,7 @@
     <div class="col-md-12">
       <h1>{{ title }}</h1>
       <p class="lead"><a href="{{ file }}">Download TSV</a></p>
+      {% if error_count_level.items() %}
       <h3>Types of errors</h3>
       <div class="report_summary"><table class="table">
       <tr><th><b>Level</b></th><th><b>Number of errors</b></th></tr>
@@ -25,6 +26,7 @@
       <p style="text-align:center; margin-top:-15px;">
         <small>Click on any term to redirect to the term page.</small>
       </p>
+      {% endif %}
       <table class="table">
         <tr>
           <th><b>Row</b></th>
@@ -33,13 +35,11 @@
           {% endfor %}
         </tr>
         {%- for row_index, row in contents.iterrows() -%}
-          <tr class={{ class_map[row['Level']]|default('table-active') }}>
+          <tr{% if error_count_level.items() %} class={{ class_map[row['Level']]|default('table-active') }}{% endif %}>
             <td>{{ row_index }}</td>
-            <td>{{ row['Level'] }}
-            <td>{{ maybe_get_link(row['Rule Name'], context) }}</td>
-            <td>{{ maybe_get_link(row['Subject'], context) }}</td>
-            <td>{{ maybe_get_link(row['Property'], context) }}</td>
-            <td>{{ maybe_get_link(row['Value']|replace("nan", ""), context) }}</td>
+            {%- for col in row %}
+            <td>{{ maybe_get_link(col|replace("nan", ""), context) }}</td>
+            {%- endfor %}
           </tr>
         {% endfor -%}
       </table>


### PR DESCRIPTION
Fixes #120

When fixing the incompleteness of ROBOT report generation, I didn't realise it was also used for the FP3 and FP7 reports, so I made it more general now.
- change default value for `limitlines` to 50 when generating FP reports instead changing in two places in the makefile 
- only assert error_count_level and error_count_rule when it's the ROBOT report
- add condition in the template to show types of error and error breakdown only when it's the ROBOT report
- generalise the row values in the table
- only change row colour accordingly to error level when it’s the ROBOT report