### PR TITLE
Properly shutdown robot gateway after execution

### DIFF
--- a/util/dashboard/dashboard.py
+++ b/util/dashboard/dashboard.py
@@ -397,13 +397,13 @@ def run():
 
         with open(dashboard_yml, 'w+') as f:
             yaml.dump(data_yml, f)
-        gateway.detach(robot_gateway)
     except Exception:
         logging.exception(f"Creating  dashboard for {ontology_file} failed")
-    try:
-        gateway.close()
-    except Exception:
-        logging.exception("Closing JavaGateway failed")
+    finally:
+        try:
+            gateway.shutdown()
+        except Exception as e:
+            logging.exception("Failed to shut down the gateway: %s", e)
 
     sys.exit(0)
 

--- a/util/dashboard/dashboard.py
+++ b/util/dashboard/dashboard.py
@@ -401,7 +401,7 @@ def run():
         logging.exception(f"Creating  dashboard for {ontology_file} failed")
     finally:
         try:
-            gateway.shutdown()
+            gateway.shutdown(raise_exception=True)
         except Exception as e:
             logging.exception("Failed to shut down the gateway: %s", e)
 


### PR DESCRIPTION
Fixes #123

Use `finally` block for cleanup actions like shutting down the gateway.
This ensures that the cleanup code runs regardless of whether an
exception was raised.