### PR TITLE
Add underscore to the regex used in `maybe_get_link` function

### DIFF
--- a/util/create_report_html.py
+++ b/util/create_report_html.py
@@ -66,6 +66,15 @@ def main(args):
 
 def maybe_get_link(cell, context):
     """
+    Returns an HTML link for the given cell value if it matches certain patterns.
+
+    Args:
+        cell (str): The cell value to check for link patterns.
+        context (dict): A dictionary containing prefix-context mappings.
+
+    Returns:
+        str: An HTML link if a matching pattern is found, otherwise the original cell value.
+
     """
     url = None
     if cell in report_doc_map:
@@ -73,7 +82,7 @@ def maybe_get_link(cell, context):
         url = report_doc_map[cell]
     else:
         # Otherwise try to parse as CURIE or IRI
-        curie = re.search(r'([A-Za-z0-9]+):([A-Za-z0-9-]+)', cell)
+        curie = re.search(r'([A-Za-z0-9_]+):([A-Za-z0-9-]+)', cell)
         if curie:
             # This is a CURIE
             prefix = curie.group(1)


### PR DESCRIPTION
Fixes #122

The link in the report page wasn't rendering link for the APOLLO_SV ontology because when checking for the curie, the regex wasn't checking
for the underscore.