### PR TITLE
Update how to set side for the colorbar in the OBO dependency graph after attribute deprecation

### DIFF
--- a/util/dashboard_analysis_html.py
+++ b/util/dashboard_analysis_html.py
@@ -300,9 +300,11 @@ def plot_graph_dependency(
             "size": node_sizes,
             "colorbar": {
                 "thickness": 15,
-                "title": "Node Connections",
+                "title": {
+                    "text": "Node Connections",
+                    "side": "right",
+                },
                 "xanchor": "left",
-                "titleside": "right"
             },
             "line_width": 2
         }


### PR DESCRIPTION
Fixes #153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the appearance of the colorbar title in the dependency graph plot for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->