### PR TITLE
Dockerfile with OBO Dashboard and its requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM obolibrary/robot:latest
+
+WORKDIR /tools
+
+# Install system dependencies
+RUN apt-get update && \
+    apt-get install -y git \
+        python3 \
+        python3-pip \
+        python3-venv \
+        python-is-python3 \
+        jq && \
+    rm -rf /var/lib/apt/lists/*
+
+
+# Copy the OBO Dashboard source code
+COPY . .
+RUN python3 -m pip install -r requirements.txt --break-system-packages
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,8 @@ RUN apt-get update && \
 COPY requirements.txt .
 # The flag 'break-system-packages' is needed to allow installing packages outside the virtual environment in some recent pip versions
 RUN python3 -m pip install -r requirements.txt --break-system-packages
+
+# Copy the OBO Dashboard source code
 COPY . .
+
+RUN chmod +x obodash

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,6 @@ RUN apt-get update && \
 
 
 # Copy the OBO Dashboard source code
-COPY . .
+COPY requirements.txt .
 RUN python3 -m pip install -r requirements.txt --break-system-packages
-
+COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,22 @@
-FROM obolibrary/robot:latest
+FROM obolibrary/robot:v1.9.8
 
 WORKDIR /tools
 
 # Install system dependencies
 RUN apt-get update && \
-    apt-get install -y git \
+    apt-get install -y --no-install-recommends \
+        git \
+        jq \
+        python-is-python3 \
         python3 \
         python3-pip \
-        python3-venv \
-        python-is-python3 \
-        jq && \
+        python3-venv && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 
 # Copy the OBO Dashboard source code
 COPY requirements.txt .
+# The flag 'break-system-packages' is needed to allow installing packages outside the virtual environment in some recent pip versions
 RUN python3 -m pip install -r requirements.txt --break-system-packages
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -163,3 +163,10 @@ tr: util/create_report_html.py dashboard/bfo/robot_report.tsv dependencies/obo_c
 dashboard/analysis.html: util/dashboard_analysis_html.py util/templates/analysis.html.jinja2
 	python3 $< --dashboard-results $(DASHBOARD_RESULTS) --template util/templates/analysis.html.jinja2 --output $@
 
+# When building docker image for the first time, create  builder for multi-arch builds
+# This is a one-time command to create the builder.
+# docker buildx create --name obo-dashboard-builder --use
+build-docker-v%:
+	docker buildx use obo-dashboard-builder
+	docker buildx build --platform linux/amd64,linux/arm64 -t anitacaron/obo-dashboard:v$* --push .
+

--- a/obodash
+++ b/obodash
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+
+cd /tools
+python ./util/dashboard_config.py rundashboard "$@"

--- a/odk.sh
+++ b/odk.sh
@@ -18,5 +18,5 @@
 
 # This is a wrapper for the OBO Dashboard Dockerfile.
 docker run -e ROBOT_JAVA_ARGS='-Xmx48G' -e JAVA_OPTS='-Xmx48G' \
-  -v $PWD/dashboard-config.yml:/tools/OBO-Dashboard/dashboard-config.yml \
-  -w /tools --rm -ti docker.io/library/obo-dashboard "$@"
+  -v $PWD/dashboard-config.yml:/tools/dashboard-config.yml \
+  -w /tools --rm -ti anitacaron/obo-dashboard:v0.1 "$@"

--- a/odk.sh
+++ b/odk.sh
@@ -9,9 +9,13 @@
 # we therefore map the whole repo (../..) to a docker volume.
 #
 # See README-editors.md for more details.
+# docker run -e ROBOT_JAVA_ARGS='-Xmx48G' -e JAVA_OPTS='-Xmx48G' \
+#   -v $PWD/dashboard:/tools/OBO-Dashboard/dashboard \
+#   -v $PWD/dashboard-config.yml:/tools/OBO-Dashboard/dashboard-config.yml \
+#   -v $PWD/ontologies:/tools/OBO-Dashboard/build/ontologies \
+#   -v $PWD/sparql:/tools/OBO-Dashboard/sparql \
+#   -w /work --rm -ti obolibrary/odkfull "$@"
+
+# This is a wrapper for the OBO Dashboard Dockerfile.
 docker run -e ROBOT_JAVA_ARGS='-Xmx48G' -e JAVA_OPTS='-Xmx48G' \
-  -v $PWD/dashboard:/tools/OBO-Dashboard/dashboard \
-  -v $PWD/dashboard-config.yml:/tools/OBO-Dashboard/dashboard-config.yml \
-  -v $PWD/ontologies:/tools/OBO-Dashboard/build/ontologies \
-  -v $PWD/sparql:/tools/OBO-Dashboard/sparql \
-  -w /work --rm -ti obolibrary/odkfull "$@"
+  -w /tools --rm -ti docker.io/library/obo-dashboard "$@"

--- a/odk.sh
+++ b/odk.sh
@@ -18,4 +18,5 @@
 
 # This is a wrapper for the OBO Dashboard Dockerfile.
 docker run -e ROBOT_JAVA_ARGS='-Xmx48G' -e JAVA_OPTS='-Xmx48G' \
+  -v $PWD/dashboard-config.yml:/tools/OBO-Dashboard/dashboard-config.yml \
   -w /tools --rm -ti docker.io/library/obo-dashboard "$@"


### PR DESCRIPTION
The aim with the Dockerfile is to easily update OBO Dashboard in different repositories (NOR, dashboard template and the OBO Dashboard itself) and not to be dependent on the ODK docker build. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Introduced a new Docker image with updated dependencies and Python packages.
  - Simplified the container run command in the script to use the new Docker image.
  - Added support for building and pushing multi-architecture Docker images.
  - Provided a new command-line script to streamline dashboard execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->