### PR TITLE
Update warning message for non-standard licenses

### DIFF
--- a/util/dashboard/fp_001.py
+++ b/util/dashboard/fp_001.py
@@ -348,7 +348,7 @@ def process_results(registry_license,
     missing_registry_license = 'Missing registry license.'
     missing_ontology_license = 'Missing ontology license.'
     load_err = 'Unable to load ontology.'
-    not_open = 'Registry license \'{0}\' is not a valid open license.'
+    not_open = 'Registry license \'{0}\' is not one of the two open licenses approved by the OBO Foundry in Principle 1: CC0 and CC-BY.'
     wrong_prop = 'License should use property \'{0}\'.'.format(license_prop)
     no_match = 'Ontology license \'{0}\' does not match registry license\
  \'{1}\'.'


### PR DESCRIPTION
Fixes #166

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated license validation message to explicitly specify OBO Foundry Principle 1-approved open licenses (CC0 and CC-BY) instead of generic phrasing about valid open licenses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->